### PR TITLE
Adopt new launcher to automatically perform animal <-> task association

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-  "aind_behavior_services@git+https://github.com/AllenNeuralDynamics/Aind.Behavior.Services@0.6.0",
+  "aind_behavior_services@git+https://github.com/AllenNeuralDynamics/Aind.Behavior.Services@6.0.1",
 ]
 
 [project.optional-dependencies]

--- a/scripts/examples.py
+++ b/scripts/examples.py
@@ -7,6 +7,7 @@ from aind_behavior_services.calibration.water_valve import (
     WaterValveCalibrationInput,
     Measurement,
 )
+from aind_behavior_services import db_utils as db
 
 import aind_behavior_vr_foraging.task_logic as vr_task_logic
 
@@ -192,12 +193,18 @@ def main():
         operation_control=operation_control,
     )
 
+    database = db.SubjectDataBase()
+    database.add_subject("test", db.SubjectEntry(task_logic_target="preward_intercept_stageA"))
+    database.add_subject("test2", db.SubjectEntry(task_logic_target="does_notexist"))
+
     with open("local/example_vr_task_logic.json", "w") as f:
         f.write(example_vr_task_logic.model_dump_json(indent=2))
     with open("local/example_session.json", "w") as f:
         f.write(example_session.model_dump_json(indent=2))
     with open("local/example_rig.json", "w") as f:
         f.write(example_rig.model_dump_json(indent=2))
+    with open("local/example_database.json", "w") as f:
+        f.write(database.model_dump_json(indent=2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #237 

See the updated example script on how to generate a valid subject list. Briefly:

```python
database = db.SubjectDataBase()
database.add_subject("test", db.SubjectEntry(task_logic_target="preward_intercept_stageA"))
database.add_subject("test2", db.SubjectEntry(task_logic_target="does_notexist"))
  with open("local/example_database.json", "w") as f:
      f.write(database.model_dump_json(indent=2))
```