### PR TITLE
Feat allow arbitrary patch depletion statistics

### DIFF
--- a/src/DataSchemas/aind_behavior_vr_foraging/task_logic.py
+++ b/src/DataSchemas/aind_behavior_vr_foraging/task_logic.py
@@ -90,7 +90,7 @@ class OperantLogic(BaseModel):
 
 class PowerFunction(BaseModel):
     function_type: Literal["PowerFunction"] = "PowerFunction"
-    mininum: float = Field(default=0, description="Minimum value of the function")
+    minimum: float = Field(default=0, description="Minimum value of the function")
     maximum: float = Field(default=1, description="Maximum value of the function")
     a: float = Field(default=1, description="Coefficient a of the function: value = a * pow(b, c * x) + d")
     b: float = Field(
@@ -102,7 +102,7 @@ class PowerFunction(BaseModel):
 
 class LinearFunction(BaseModel):
     function_type: Literal["LinearFunction"] = "LinearFunction"
-    mininum: float = Field(default=0, description="Minimum value of the function")
+    minimum: float = Field(default=0, description="Minimum value of the function")
     maximum: float = Field(default=9999, description="Maximum value of the function")
     a: float = Field(default=1, description="Coefficient a of the function: value = a * x + b")
     b: float = Field(default=0, description="Coefficient b of the function: value = a * x + b")
@@ -151,7 +151,7 @@ class PatchRewardFunction(BaseModel):
         validate_default=True,
     )
     available: RewardFunction = Field(
-        default=LinearFunction(mininum=0, a=-1, b=5),
+        default=LinearFunction(minimum=0, a=-1, b=5),
         description="Determines the total amount of reward available left in the patch. The value is in microliters",
         validate_default=True,
     )

--- a/src/DataSchemas/aind_behavior_vr_foraging/task_logic.py
+++ b/src/DataSchemas/aind_behavior_vr_foraging/task_logic.py
@@ -118,9 +118,9 @@ class RewardFunction(RootModel):
 
 
 class DepletionRule(str, Enum):
-    ON_REWARD = ("OnReward",)
-    ON_CHOICE = ("OnChoice",)
-    ON_TIME = ("OnTime",)
+    ON_REWARD = "OnReward"
+    ON_CHOICE = "OnChoice"
+    ON_TIME = "OnTime"
     ON_DISTANCE = "OnDistance"
 
 

--- a/src/DataSchemas/aind_vr_foraging_task_logic.json
+++ b/src/DataSchemas/aind_vr_foraging_task_logic.json
@@ -581,10 +581,10 @@
           "title": "Function Type",
           "type": "string"
         },
-        "mininum": {
+        "minimum": {
           "default": 0,
           "description": "Minimum value of the function",
-          "title": "Mininum",
+          "title": "Minimum",
           "type": "number"
         },
         "maximum": {
@@ -1085,7 +1085,7 @@
           ],
           "default": {
             "function_type": "LinearFunction",
-            "mininum": 0.0,
+            "minimum": 0.0,
             "maximum": 9999.0,
             "a": -1.0,
             "b": 5.0
@@ -1329,10 +1329,10 @@
           "title": "Function Type",
           "type": "string"
         },
-        "mininum": {
+        "minimum": {
           "default": 0,
           "description": "Minimum value of the function",
-          "title": "Mininum",
+          "title": "Minimum",
           "type": "number"
         },
         "maximum": {
@@ -1467,7 +1467,7 @@
               "b": 5.0,
               "function_type": "LinearFunction",
               "maximum": 9999.0,
-              "mininum": 0.0
+              "minimum": 0.0
             },
             "depletion_rule": "OnChoice"
           },

--- a/src/DataSchemas/aind_vr_foraging_task_logic.json
+++ b/src/DataSchemas/aind_vr_foraging_task_logic.json
@@ -682,6 +682,40 @@
       "title": "LogNormalDistributionParameters",
       "type": "object"
     },
+    "LookupTableFunction": {
+      "properties": {
+        "function_type": {
+          "const": "LookupTableFunction",
+          "default": "LookupTableFunction",
+          "title": "Function Type",
+          "type": "string"
+        },
+        "lut_keys": {
+          "description": "List of keys of the lookup table",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 1,
+          "title": "Lut Keys",
+          "type": "array"
+        },
+        "lut_values": {
+          "description": "List of values of the lookup table",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 1,
+          "title": "Lut Values",
+          "type": "array"
+        }
+      },
+      "required": [
+        "lut_keys",
+        "lut_values"
+      ],
+      "title": "LookupTableFunction",
+      "type": "object"
+    },
     "MovableSpoutControl": {
       "properties": {
         "enabled": {
@@ -1361,6 +1395,7 @@
         "mapping": {
           "ConstantFunction": "#/definitions/ConstantFunction",
           "LinearFunction": "#/definitions/LinearFunction",
+          "LookupTableFunction": "#/definitions/LookupTableFunction",
           "PowerFunction": "#/definitions/PowerFunction"
         },
         "propertyName": "function_type"
@@ -1374,6 +1409,9 @@
         },
         {
           "$ref": "#/definitions/PowerFunction"
+        },
+        {
+          "$ref": "#/definitions/LookupTableFunction"
         }
       ],
       "title": "RewardFunction"

--- a/src/Extensions/AindVrForagingTaskLogic.cs
+++ b/src/Extensions/AindVrForagingTaskLogic.cs
@@ -1809,6 +1809,86 @@ namespace AindVrForagingDataSchema.TaskLogic
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Bonsai.Sgen", "0.3.0.0 (Newtonsoft.Json v13.0.0.0)")]
     [Bonsai.CombinatorAttribute()]
     [Bonsai.WorkflowElementCategoryAttribute(Bonsai.ElementCategory.Source)]
+    public partial class LookupTableFunction : RewardFunction
+    {
+    
+        private System.Collections.Generic.List<double> _lutKeys = new System.Collections.Generic.List<double>();
+    
+        private System.Collections.Generic.List<double> _lutValues = new System.Collections.Generic.List<double>();
+    
+        public LookupTableFunction()
+        {
+        }
+    
+        protected LookupTableFunction(LookupTableFunction other) : 
+                base(other)
+        {
+            _lutKeys = other._lutKeys;
+            _lutValues = other._lutValues;
+        }
+    
+        /// <summary>
+        /// List of keys of the lookup table
+        /// </summary>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        [Newtonsoft.Json.JsonPropertyAttribute("lut_keys", Required=Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DescriptionAttribute("List of keys of the lookup table")]
+        public System.Collections.Generic.List<double> LutKeys
+        {
+            get
+            {
+                return _lutKeys;
+            }
+            set
+            {
+                _lutKeys = value;
+            }
+        }
+    
+        /// <summary>
+        /// List of values of the lookup table
+        /// </summary>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        [Newtonsoft.Json.JsonPropertyAttribute("lut_values", Required=Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DescriptionAttribute("List of values of the lookup table")]
+        public System.Collections.Generic.List<double> LutValues
+        {
+            get
+            {
+                return _lutValues;
+            }
+            set
+            {
+                _lutValues = value;
+            }
+        }
+    
+        public System.IObservable<LookupTableFunction> Process()
+        {
+            return System.Reactive.Linq.Observable.Defer(() => System.Reactive.Linq.Observable.Return(new LookupTableFunction(this)));
+        }
+    
+        public System.IObservable<LookupTableFunction> Process<TSource>(System.IObservable<TSource> source)
+        {
+            return System.Reactive.Linq.Observable.Select(source, _ => new LookupTableFunction(this));
+        }
+    
+        protected override bool PrintMembers(System.Text.StringBuilder stringBuilder)
+        {
+            if (base.PrintMembers(stringBuilder))
+            {
+                stringBuilder.Append(", ");
+            }
+            stringBuilder.Append("lut_keys = " + _lutKeys + ", ");
+            stringBuilder.Append("lut_values = " + _lutValues);
+            return true;
+        }
+    }
+
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Bonsai.Sgen", "0.3.0.0 (Newtonsoft.Json v13.0.0.0)")]
+    [Bonsai.CombinatorAttribute()]
+    [Bonsai.WorkflowElementCategoryAttribute(Bonsai.ElementCategory.Source)]
     public partial class MovableSpoutControl
     {
     
@@ -3684,6 +3764,7 @@ namespace AindVrForagingDataSchema.TaskLogic
     [JsonInheritanceAttribute("ConstantFunction", typeof(ConstantFunction))]
     [JsonInheritanceAttribute("LinearFunction", typeof(LinearFunction))]
     [JsonInheritanceAttribute("PowerFunction", typeof(PowerFunction))]
+    [JsonInheritanceAttribute("LookupTableFunction", typeof(LookupTableFunction))]
     [Bonsai.CombinatorAttribute()]
     [Bonsai.WorkflowElementCategoryAttribute(Bonsai.ElementCategory.Source)]
     public partial class RewardFunction
@@ -6016,6 +6097,7 @@ namespace AindVrForagingDataSchema.TaskLogic
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<ConstantFunction>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<LinearFunction>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<PowerFunction>))]
+    [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<LookupTableFunction>))]
     public partial class MatchRewardFunction : Bonsai.Expressions.SingleArgumentExpressionBuilder
     {
     
@@ -6202,6 +6284,11 @@ namespace AindVrForagingDataSchema.TaskLogic
         public System.IObservable<string> Process(System.IObservable<LogNormalDistributionParameters> source)
         {
             return Process<LogNormalDistributionParameters>(source);
+        }
+
+        public System.IObservable<string> Process(System.IObservable<LookupTableFunction> source)
+        {
+            return Process<LookupTableFunction>(source);
         }
 
         public System.IObservable<string> Process(System.IObservable<MovableSpoutControl> source)
@@ -6417,6 +6504,7 @@ namespace AindVrForagingDataSchema.TaskLogic
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<LinearFunction>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<LogNormalDistribution>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<LogNormalDistributionParameters>))]
+    [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<LookupTableFunction>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<MovableSpoutControl>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<NormalDistribution>))]
     [System.Xml.Serialization.XmlIncludeAttribute(typeof(Bonsai.Expressions.TypeMapping<NormalDistributionParameters>))]

--- a/src/Extensions/AindVrForagingTaskLogic.cs
+++ b/src/Extensions/AindVrForagingTaskLogic.cs
@@ -1487,7 +1487,7 @@ namespace AindVrForagingDataSchema.TaskLogic
     public partial class LinearFunction : RewardFunction
     {
     
-        private double _mininum = 0D;
+        private double _minimum = 0D;
     
         private double _maximum = 9999D;
     
@@ -1502,7 +1502,7 @@ namespace AindVrForagingDataSchema.TaskLogic
         protected LinearFunction(LinearFunction other) : 
                 base(other)
         {
-            _mininum = other._mininum;
+            _minimum = other._minimum;
             _maximum = other._maximum;
             _a = other._a;
             _b = other._b;
@@ -1511,17 +1511,17 @@ namespace AindVrForagingDataSchema.TaskLogic
         /// <summary>
         /// Minimum value of the function
         /// </summary>
-        [Newtonsoft.Json.JsonPropertyAttribute("mininum")]
+        [Newtonsoft.Json.JsonPropertyAttribute("minimum")]
         [System.ComponentModel.DescriptionAttribute("Minimum value of the function")]
-        public double Mininum
+        public double Minimum
         {
             get
             {
-                return _mininum;
+                return _minimum;
             }
             set
             {
-                _mininum = value;
+                _minimum = value;
             }
         }
     
@@ -1592,7 +1592,7 @@ namespace AindVrForagingDataSchema.TaskLogic
             {
                 stringBuilder.Append(", ");
             }
-            stringBuilder.Append("mininum = " + _mininum + ", ");
+            stringBuilder.Append("minimum = " + _minimum + ", ");
             stringBuilder.Append("maximum = " + _maximum + ", ");
             stringBuilder.Append("a = " + _a + ", ");
             stringBuilder.Append("b = " + _b);
@@ -3537,7 +3537,7 @@ namespace AindVrForagingDataSchema.TaskLogic
     public partial class PowerFunction : RewardFunction
     {
     
-        private double _mininum = 0D;
+        private double _minimum = 0D;
     
         private double _maximum = 1D;
     
@@ -3556,7 +3556,7 @@ namespace AindVrForagingDataSchema.TaskLogic
         protected PowerFunction(PowerFunction other) : 
                 base(other)
         {
-            _mininum = other._mininum;
+            _minimum = other._minimum;
             _maximum = other._maximum;
             _a = other._a;
             _b = other._b;
@@ -3567,17 +3567,17 @@ namespace AindVrForagingDataSchema.TaskLogic
         /// <summary>
         /// Minimum value of the function
         /// </summary>
-        [Newtonsoft.Json.JsonPropertyAttribute("mininum")]
+        [Newtonsoft.Json.JsonPropertyAttribute("minimum")]
         [System.ComponentModel.DescriptionAttribute("Minimum value of the function")]
-        public double Mininum
+        public double Minimum
         {
             get
             {
-                return _mininum;
+                return _minimum;
             }
             set
             {
-                _mininum = value;
+                _minimum = value;
             }
         }
     
@@ -3682,7 +3682,7 @@ namespace AindVrForagingDataSchema.TaskLogic
             {
                 stringBuilder.Append(", ");
             }
-            stringBuilder.Append("mininum = " + _mininum + ", ");
+            stringBuilder.Append("minimum = " + _minimum + ", ");
             stringBuilder.Append("maximum = " + _maximum + ", ");
             stringBuilder.Append("a = " + _a + ", ");
             stringBuilder.Append("b = " + _b + ", ");

--- a/src/Extensions/ApplyRewardFunction.cs
+++ b/src/Extensions/ApplyRewardFunction.cs
@@ -1,8 +1,10 @@
 using Bonsai;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Linq;
+using MathNet.Numerics.Interpolation;
 
 namespace AindVrForagingDataSchema.TaskLogic
 {
@@ -41,6 +43,31 @@ namespace AindVrForagingDataSchema.TaskLogic
     partial class ConstantFunction{
         public override double Invoke(double value){
             return Value;
+        }
+
+        public override double Clamp(double value){
+            return value;
+        }
+    }
+
+    partial class LookupTableFunction{
+
+
+        private Dictionary<double, double> LookupTable(){
+            return LutKeys.Zip(LutValues, (key, value) => new { Key = key, Value = value })
+                         .ToDictionary(x => x.Key, x => x.Value);
+        }
+
+        public override double Invoke(double value){
+            Dictionary<double, double> Table = LookupTable();
+            if (value > Table.Keys.Max()){
+                return Table[Table.Keys.Max()];
+            }
+            if (value < Table.Keys.Min()){
+                return Table[Table.Keys.Min()];
+            }
+            IInterpolation interpolation = MathNet.Numerics.Interpolate.Linear(Table.Keys, Table.Values);
+            return interpolation.Interpolate(value);
         }
 
         public override double Clamp(double value){

--- a/src/Extensions/ApplyRewardFunction.cs
+++ b/src/Extensions/ApplyRewardFunction.cs
@@ -26,7 +26,7 @@ namespace AindVrForagingDataSchema.TaskLogic
         }
 
         public override double Clamp(double value){
-            return Math.Min(Math.Max(value, Mininum), Maximum);
+            return Math.Min(Math.Max(value, Minimum), Maximum);
         }
     }
 
@@ -36,7 +36,7 @@ namespace AindVrForagingDataSchema.TaskLogic
         }
 
         public override double Clamp(double value){
-            return Math.Min(Math.Max(value, Mininum), Maximum);
+            return Math.Min(Math.Max(value, Minimum), Maximum);
         }
     }
 

--- a/tests/test_bonsai.py
+++ b/tests/test_bonsai.py
@@ -11,8 +11,8 @@ from aind_behavior_vr_foraging.task_logic import AindVrForagingTaskLogic
 from pydantic import ValidationError
 
 sys.path.append(".")
-from examples import examples  # noqa: E402 # isort:skip # pylint: disable=wrong-import-position
-from tests import JSON_ROOT  # noqa: E402 # isort:skip # pylint: disable=wrong-import-position
+from examples import examples  # isort:skip # pylint: disable=wrong-import-position
+from tests import JSON_ROOT  # isort:skip # pylint: disable=wrong-import-position
 
 TModel = TypeVar("TModel", bound=Union[AindVrForagingRig, AindVrForagingTaskLogic, AindBehaviorSessionModel])
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,11 +1,11 @@
-""" testing examples """
+"""testing examples"""
 
 import glob
 import sys
 import unittest
 
 sys.path.append(".")
-from tests import EXAMPLES_DIR, build_example  # noqa: E402 # isort:skip # pylint: disable=wrong-import-position
+from tests import EXAMPLES_DIR, build_example  # isort:skip # pylint: disable=wrong-import-position
 
 
 class ExampleTests(unittest.TestCase):


### PR DESCRIPTION
Closes #280 

This PR allows the specification of a depletion reward function via a lookup table.
All rules relative to the previous functions remain the same. Briefly:

The dependent variable, X will be used to draw from an Math.Net.Interpolating Interpolator class that gets created by using Keys and Values. 

If the provided X is outside the interpolator domain, the value of the min/max key will be automatically returned.
