### PR TITLE
Update default duty cycle for speaker

### DIFF
--- a/src/vr-foraging.bonsai
+++ b/src/vr-foraging.bonsai
@@ -420,23 +420,6 @@ Item3 as Right)</scr:Expression>
                   <Expression xsi:type="rx:PublishSubject">
                     <Name>HarpWhiteRabbitHeartbeat</Name>
                   </Expression>
-                  <Expression xsi:type="Annotation">
-                    <Name>PinOut</Name>
-                    <Text><![CDATA[| Function | HarpBehavior Pin | Notes |
-| --- | ----------- | ----------- |
-| Camera Trigger | DO0 |  |
-| Water Valve | Port0 Supply |  Use a poke breakout |
-| Lickometer | Port0 DI |  Use a poke breakout |
-| Encoder B | Port2 DIO | Use a poke breakout |
-| Encoder A | Port2 DI | Use a poke breakout |
-| Thermistor | ADC0 |  |
-| Pressure Sensor | ADC1 |  |
-| Photodiode | DI3 |  |
-| Servo Motor | DO2 |  |
-| Audio Buzzer | DO1 |  |
-
-]]></Text>
-                  </Expression>
                   <Expression xsi:type="IncludeWorkflow" Path="Extensions\HarpBehaviorDevice.bonsai">
                     <TriggerHarpReadDumpSubjectName>TriggerHarpReadDump</TriggerHarpReadDumpSubjectName>
                   </Expression>
@@ -622,51 +605,50 @@ Item3 as Right)</scr:Expression>
                   <Edge From="3" To="4" Label="Source1" />
                   <Edge From="5" To="6" Label="Source1" />
                   <Edge From="6" To="7" Label="Source1" />
-                  <Edge From="8" To="9" Label="Source1" />
+                  <Edge From="9" To="10" Label="Source1" />
                   <Edge From="10" To="11" Label="Source1" />
                   <Edge From="11" To="12" Label="Source1" />
-                  <Edge From="12" To="13" Label="Source1" />
+                  <Edge From="13" To="14" Label="Source1" />
                   <Edge From="14" To="15" Label="Source1" />
                   <Edge From="15" To="16" Label="Source1" />
-                  <Edge From="16" To="17" Label="Source1" />
+                  <Edge From="17" To="18" Label="Source1" />
                   <Edge From="18" To="19" Label="Source1" />
                   <Edge From="19" To="20" Label="Source1" />
-                  <Edge From="20" To="21" Label="Source1" />
+                  <Edge From="21" To="22" Label="Source1" />
                   <Edge From="22" To="23" Label="Source1" />
                   <Edge From="23" To="24" Label="Source1" />
                   <Edge From="24" To="25" Label="Source1" />
-                  <Edge From="25" To="26" Label="Source1" />
+                  <Edge From="26" To="27" Label="Source1" />
                   <Edge From="27" To="28" Label="Source1" />
                   <Edge From="28" To="29" Label="Source1" />
                   <Edge From="29" To="30" Label="Source1" />
                   <Edge From="30" To="31" Label="Source1" />
-                  <Edge From="31" To="32" Label="Source1" />
-                  <Edge From="32" To="37" Label="Source1" />
+                  <Edge From="31" To="36" Label="Source1" />
+                  <Edge From="32" To="33" Label="Source1" />
                   <Edge From="33" To="34" Label="Source1" />
                   <Edge From="34" To="35" Label="Source1" />
-                  <Edge From="35" To="36" Label="Source1" />
-                  <Edge From="36" To="37" Label="Source2" />
+                  <Edge From="35" To="36" Label="Source2" />
+                  <Edge From="37" To="38" Label="Source1" />
                   <Edge From="38" To="39" Label="Source1" />
                   <Edge From="39" To="40" Label="Source1" />
-                  <Edge From="40" To="41" Label="Source1" />
-                  <Edge From="41" To="45" Label="Source1" />
+                  <Edge From="40" To="44" Label="Source1" />
+                  <Edge From="41" To="42" Label="Source1" />
                   <Edge From="42" To="43" Label="Source1" />
-                  <Edge From="43" To="44" Label="Source1" />
-                  <Edge From="44" To="45" Label="Source2" />
+                  <Edge From="43" To="44" Label="Source2" />
+                  <Edge From="45" To="46" Label="Source1" />
                   <Edge From="46" To="47" Label="Source1" />
                   <Edge From="47" To="48" Label="Source1" />
-                  <Edge From="48" To="49" Label="Source1" />
-                  <Edge From="49" To="53" Label="Source1" />
+                  <Edge From="48" To="52" Label="Source1" />
+                  <Edge From="49" To="50" Label="Source1" />
                   <Edge From="50" To="51" Label="Source1" />
-                  <Edge From="51" To="52" Label="Source1" />
-                  <Edge From="52" To="53" Label="Source2" />
+                  <Edge From="51" To="52" Label="Source2" />
+                  <Edge From="53" To="54" Label="Source1" />
                   <Edge From="54" To="55" Label="Source1" />
                   <Edge From="55" To="56" Label="Source1" />
-                  <Edge From="56" To="57" Label="Source1" />
-                  <Edge From="57" To="61" Label="Source1" />
+                  <Edge From="56" To="60" Label="Source1" />
+                  <Edge From="57" To="58" Label="Source1" />
                   <Edge From="58" To="59" Label="Source1" />
-                  <Edge From="59" To="60" Label="Source1" />
-                  <Edge From="60" To="61" Label="Source2" />
+                  <Edge From="59" To="60" Label="Source2" />
                 </Edges>
               </Workflow>
             </Expression>
@@ -6299,7 +6281,7 @@ Item1 as Displacement,
                         <Expression xsi:type="beh:CreateMessage">
                           <harp:MessageType>Write</harp:MessageType>
                           <harp:Payload xsi:type="beh:CreatePwmDutyCycleDO2Payload">
-                            <beh:PwmDutyCycleDO2>1</beh:PwmDutyCycleDO2>
+                            <beh:PwmDutyCycleDO2>50</beh:PwmDutyCycleDO2>
                           </harp:Payload>
                         </Expression>
                         <Expression xsi:type="Combinator">


### PR DESCRIPTION
This PR fixes a bug where the duty cycle of the PWM that triggers the speaker was set to "1".